### PR TITLE
Update DOMPoint to match the current draft spec (the one actually implemented by browsers)

### DIFF
--- a/src/DOMPoint.js
+++ b/src/DOMPoint.js
@@ -25,12 +25,21 @@ class DOMPointReadOnly {
         _(this).y = (y !== undefined) ? Number(y) : 0
         _(this).z = (z !== undefined) ? Number(z) : 0
         _(this).w = (w !== undefined) ? Number(w) : 1
+
+        if (this.constructor === DOMPointReadOnly) {
+            Object.freeze(_(this))
+        }
     }
 
     get x() { return _(this).x }
     get y() { return _(this).y }
     get z() { return _(this).z }
     get w() { return _(this).w }
+
+    set x(value) { _(this).x = Number(value) }
+    set y(value) { _(this).y = Number(value) }
+    set z(value) { _(this).z = Number(value) }
+    set w(value) { _(this).w = Number(value) }
 
     matrixTransform(matrix) {
         let result = new this.constructor(this)
@@ -49,11 +58,6 @@ class DOMPointReadOnly {
 }
 
 export
-class DOMPoint extends DOMPointReadOnly {
-    set x(value) { _(this).x = Number(value) }
-    set y(value) { _(this).y = Number(value) }
-    set z(value) { _(this).z = Number(value) }
-    set w(value) { _(this).w = Number(value) }
-}
+class DOMPoint extends DOMPointReadOnly {}
 
 export default DOMPoint

--- a/src/DOMPoint.js
+++ b/src/DOMPoint.js
@@ -52,6 +52,8 @@ class DOMPointReadOnly {
         return result
     }
 
+    toJSON() { return Object.assign({}, _(this)) }
+
     static fromPoint(other) {
         return new this(other.x, other.y, other.z, other.w)
     }

--- a/src/DOMPoint.js
+++ b/src/DOMPoint.js
@@ -21,24 +21,10 @@ const _ = o => {
 export
 class DOMPointReadOnly {
     constructor(x,y,z,w) {
-        if (arguments.length === 1) {
-            if (!isDOMPointInit(x))
-                throw new TypeError('Expected an object with x, y, z, and w properties')
-
-            _(this).x = x.x
-            _(this).y = x.y
-            _(this).z = x.z
-            _(this).w = x.w
-        }
-        else if (arguments.length === 4)  {
-            _(this).x = x || 0
-            _(this).y = y || 0
-            _(this).z = z || 0
-            _(this).w = w || 0
-        }
-        else {
-            throw new TypeError('Expected 1 or 4 arguments')
-        }
+        _(this).x = (x !== undefined) ? Number(x) : 0
+        _(this).y = (y !== undefined) ? Number(y) : 0
+        _(this).z = (z !== undefined) ? Number(z) : 0
+        _(this).w = (w !== undefined) ? Number(w) : 1
     }
 
     get x() { return _(this).x }
@@ -58,29 +44,16 @@ class DOMPointReadOnly {
     }
 
     static fromPoint(other) {
-        return new this(other)
+        return new this(other.x, other.y, other.z, other.w)
     }
 }
 
 export
 class DOMPoint extends DOMPointReadOnly {
-    set x(value) { _(this).x = value }
-    set y(value) { _(this).y = value }
-    set z(value) { _(this).z = value }
-    set w(value) { _(this).w = value }
+    set x(value) { _(this).x = Number(value) }
+    set y(value) { _(this).y = Number(value) }
+    set z(value) { _(this).z = Number(value) }
+    set w(value) { _(this).w = Number(value) }
 }
 
 export default DOMPoint
-
-function isDOMPointInit(o) {
-    if (typeof o != 'object') return false
-
-    if (
-        'x' in o &&
-        'y' in o &&
-        'z' in o &&
-        'w' in o
-    ) return true
-
-    return false
-}

--- a/src/DOMPoint.js
+++ b/src/DOMPoint.js
@@ -25,21 +25,12 @@ class DOMPointReadOnly {
         _(this).y = (y !== undefined) ? Number(y) : 0
         _(this).z = (z !== undefined) ? Number(z) : 0
         _(this).w = (w !== undefined) ? Number(w) : 1
-
-        if (this.constructor === DOMPointReadOnly) {
-            Object.freeze(_(this))
-        }
     }
 
     get x() { return _(this).x }
     get y() { return _(this).y }
     get z() { return _(this).z }
     get w() { return _(this).w }
-
-    set x(value) { _(this).x = Number(value) }
-    set y(value) { _(this).y = Number(value) }
-    set z(value) { _(this).z = Number(value) }
-    set w(value) { _(this).w = Number(value) }
 
     matrixTransform(matrix) {
         let result = new this.constructor(this)
@@ -60,6 +51,16 @@ class DOMPointReadOnly {
 }
 
 export
-class DOMPoint extends DOMPointReadOnly {}
+class DOMPoint extends DOMPointReadOnly {
+    get x() { return super.x }
+    get y() { return super.y }
+    get z() { return super.z }
+    get w() { return super.w }
+
+    set x(value) { _(this).x = Number(value) }
+    set y(value) { _(this).y = Number(value) }
+    set z(value) { _(this).z = Number(value) }
+    set w(value) { _(this).w = Number(value) }
+}
 
 export default DOMPoint


### PR DESCRIPTION
https://drafts.fxtf.org/geometry/ is the _de facto_ standard. 
The 2014 candidate recommendation, https://www.w3.org/TR/geometry-1/, is obsolete.

This fixes #5 and helps with #3.